### PR TITLE
Fix verification bug

### DIFF
--- a/src/runner.cu
+++ b/src/runner.cu
@@ -107,7 +107,7 @@ bool verify_matrix(float *matRef, float *matOut, int N) {
   int i;
   for (i = 0; i < N; i++) {
     diff = std::fabs(matRef[i] - matOut[i]);
-    if (diff > 0.01) {
+    if (isnan(diff) || diff > 0.01) {
       printf("Divergence! Should %5.2f, Is %5.2f (Diff %5.2f) at %d\n",
              matRef[i], matOut[i], diff, i);
       return false;


### PR DESCRIPTION
First of all, thank you for this amazing resource!

I have been reconstructing various kernels while learning from your blog and this repository. At one point, one of my kernels had unusually high GFLOPS which really perplexed me. It took me a while before I discovered I had a bug in my verification function which didn't check for NaN values. I have been using my own custom verification function but out of curiosity I checked the one in this project and discovered it suffers from the same problem.

Even though I encountered this problem in one of the more advanced kernels, it can be reproduced in the simpler ones too.  The simplest way to reproduce this is to make a change [here](https://github.com/siboehm/SGEMM_CUDA/blob/master/src/kernels/4_kernel_1D_blocktiling.cuh#L48):

```
// Replaced TM with 2
float threadResults[2] = {0.0};
```

Then, after compiling and running `./sgemm 4` the GFLOPS are very high (kernel is doing less work because of invalid memory accesses) but the verification succeeds.

This PR fixes the verification.